### PR TITLE
Updating license footer for JB deployment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,13 @@ html:
   comments:
     utterances:
       repo: "OceanGlidersCommunity/Salinity_SOP"
+  extra_footer: |
+    <p>  By the OceanGliders community using
+      <a href="https://jupyterbook.org/intro.html"   target="_blank">Jupyter Book</a>. 
+      This work is licensed under a 
+      <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"> Creative Commons Attribution 4.0 Generic License.</a> 
+    </p>      
+      
 bibtex_bibfiles:
     - salinity.bib
 sphinx:

--- a/_config.yml
+++ b/_config.yml
@@ -26,3 +26,4 @@ bibtex_bibfiles:
 sphinx:
   config:
     bibtex_reference_style: author_year
+    html_show_copyright: false

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,6 @@
 title: "Salinity SOP"
+copyright: ""
+author: ""
 logo: images/logo-ocean-gliders.png
 execute:
   execute_notebooks: "off"


### PR DESCRIPTION
In this PR I replace the default license/copyright statement with an extra_footer expressing the `OceanGliders` Community as the creator and acknowledging Jupyter Books and stating the open access copyright.