### PR TITLE
typo and add link to RBR coda DO sensor

### DIFF
--- a/sections/salinity_sensors_integration.md
+++ b/sections/salinity_sensors_integration.md
@@ -55,7 +55,7 @@ The RBR*legato*<sup>3</sup>, unlike the previously mentioned sensors, has an ind
 Its advantages are a large unpumped flow cell, reducing occurrence of spikes due to bubbles and fouling. 
 As such, it is very good for near-surface applications and slow glider speeds, as well as for glider missions involving instrumentation sensitive to vibration (e.g., shear probes) or noise (e.g., acoustic packages). 
 The RBR*legato*<sup>3</sup> has low power consumption (45 mW) when sampling at 2 Hz. Its profile and low power have many benefits, but the inductive cell and relative youth of the sensor leave some open questions regarding long term accuracy.
-As a logger, the RBR*legato*<sup>3</sup> can also integrate other RBR sensors (such as the oxygen optode RBR*coda*3<sup>3</sup> T.ODO) enabling fast 16 Hz sampling even if the glider platform does not have the capability onboard and reduces the number of sensor ports required to connect to the glider. 
+As a logger, the RBR*legato*<sup>3</sup> can also integrate other RBR sensors (such as the oxygen optode [RBR*coda*<sup>3</sup> T.ODO](https://rbr-global.com/products/sensors/rbrcoda-todo)) enabling fast 16 Hz sampling even if the glider platform does not have the capability onboard and reduces the number of sensor ports required to connect to the glider. 
 
 The RBR*legato*<sup>3</sup> has a manufacturer-provided accuracy of ±0.0003 S m<sup>-1</sup> over a range of 0 to 9 S m<sup>-1</sup> for Conductivity, 0.002<sup>o</sup>C (ITS-90) over a range of -5 to +35<sup>o</sup>C for Temperature, and ±0.05% full scale for Pressure, up to 1000 m. 
 


### PR DESCRIPTION


Remove duplication of 3 in sensor name and add a link to RBR site, in same manner as link to RBR legato