### PR TITLE
add RTQC meeting to development process

### DIFF
--- a/sections/authors_SOP_development_process.md
+++ b/sections/authors_SOP_development_process.md
@@ -38,6 +38,9 @@ Meeting participants: [Soeren Thomsen](https://github.com/soerenthomsen), [Isabe
 
 6) New authors joined during the community review: John Allen, [Robert E. Todd](https://github.com/rtodd-WHOI) and [Callum Rollo](https://github.com/callumrollo).
 
+7) Virtual meeting to collect issues on Real Time QC T&S on June 21 2022 organized by Victor Turpin, [Isabelle Giddy](https://github.com/patricialg), Corentin Guyot and [Soeren Thomsen](https://github.com/soerenthomsen). [Agenda](create md file)
+Meeting participants: Soeren Thomsen, Isabelle Giddy, ...
+
 ## Contributions 
 
 [Isabelle Giddy](https://github.com/isgiddy) Restructured and revised the initial draft document after Soeren Thomsen and Donglai Gong. 


### PR DESCRIPTION
Dear @callumrollo and @isgiddy, 

I added our meeting today to the process and would like to create a agenda and notes *md file so that other people can later see the meeting notes and no key issues get lost.

@callumrollo are you willing to support this?

I have to chair the session so might not be able to take notes but support whenever I can!

@castelao in case you cannot make it today we try to document everything [here](https://github.com/OceanGlidersCommunity/Salinity_SOP/blob/main/meeting_notes/2022_06_20_RTQC_session.md)