### PR TITLE
PR to test GitHub pages building

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This [GitHub repository](https://github.com/OceanGlidersCommunity/Salinity_SOP) 
 
 Read the SOP [here](https://oceangliderscommunity.github.io/Salinity_SOP/README.html). 
 
-Everyone is welcome to join the SOP at any time. 
+Everyone is welcome to join the SOP at any time.
 
 ## Community review
 The community review is open from November 2021 to June 30 2022.


### PR DESCRIPTION
I checked in the repo settings -> Pages 

and indeed there was a problem. The source was not specified anymore. Weird.

It was like this: 
<img width="760" alt="Screenshot 2022-06-22 at 10 21 00" src="https://user-images.githubusercontent.com/32633545/174980956-9ea44970-3bac-4cff-ab45-3766dd5516c1.png">

Should look like this (Oxygen SOP)

<img width="758" alt="Screenshot 2022-06-22 at 10 20 32" src="https://user-images.githubusercontent.com/32633545/174981031-7ea32eb2-de75-40c1-b706-6012f5301249.png">

