### PR TITLE
update GitHub actions and requirements

### DIFF
--- a/.github/workflows/build_book.yml
+++ b/.github/workflows/build_book.yml
@@ -25,7 +25,7 @@ jobs:
 
       # Install dependencies
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 jupyter-book==0.12.3
 pyppeteer
-pybtex-apa-style
+pybtex-apa-style>=1.3


### PR DESCRIPTION
As already done for the Oxygen SOP to reduce the warnings during the building. https://github.com/OceanGlidersCommunity/Oxygen_SOP/pull/249